### PR TITLE
Update parameters and dependencies of all learners

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mlr3learners 0.1.5
 
-* Added parameter and parameter dependencies to `regr.glmnet`, `regr.km`,  `regr.ranger`, `regr.svm`, `regr.xgboost`, `classif.glmnet`,  `classif.lda`, `classif.naivebayes`, `classif.qda`, `classif.ranger` and `classif.svm`.
+* Added parameter and parameter dependencies to `regr.glmnet`, `regr.km`, `regr.ranger`, `regr.svm`, `regr.xgboost`, `classif.glmnet`, `classif.lda`, `classif.naivebayes`, `classif.qda`, `classif.ranger` and `classif.svm`.
 * Added `relax` parameter of `glmnet` 3.0 
 * Updated `*.xgboost` parameter to `xgboost` 0.90.0.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Added parameter and parameter dependencies to `regr.glmnet`, `regr.km`, `regr.ranger`, `regr.svm`, `regr.xgboost`, `classif.glmnet`, `classif.lda`, `classif.naivebayes`, `classif.qda`, `classif.ranger` and `classif.svm`.
 * glmnet: Added `relax` parameter (v3.0)
-* Updated `*.xgboost` parameter to `xgboost` 0.90.0.2
+* xgboost: Updated parameters to v0.90.0.2
 
 # mlr3learners 0.1.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # mlr3learners 0.1.5
 
 * Added parameter and parameter dependencies to `regr.glmnet`, `regr.km`, `regr.ranger`, `regr.svm`, `regr.xgboost`, `classif.glmnet`, `classif.lda`, `classif.naivebayes`, `classif.qda`, `classif.ranger` and `classif.svm`.
-* Added `relax` parameter of `glmnet` 3.0 
+* glmnet: Added `relax` parameter (v3.0)
 * Updated `*.xgboost` parameter to `xgboost` 0.90.0.2
 
 # mlr3learners 0.1.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# mlr3learners 0.1.5
+
+* Added parameter and parameter dependencies to `regr.glmnet`, `regr.km`,  `regr.ranger`, `regr.svm`, `regr.xgboost`, `classif.glmnet`,  `classif.lda`, `classif.naivebayes`, `classif.qda`, `classif.ranger` and `classif.svm`.
+* Added `relax` parameter of `glmnet` 3.0 
+* Updated `*.xgboost` parameter to `xgboost` 0.90.0.2
+
 # mlr3learners 0.1.4
 
 * Fixed a bug in `*.xgboost` and `*.svm` which was triggered if columns

--- a/R/LearnerClassifGlmnet.R
+++ b/R/LearnerClassifGlmnet.R
@@ -45,6 +45,8 @@ LearnerClassifGlmnet = R6Class("LearnerClassifGlmnet", inherit = LearnerClassif,
         ParamInt$new("maxit", default = 100000L, lower = 1L, tags = "train"),
         ParamFct$new("type.logistic", levels = c("Newton", "modified.Newton"), tags = "train"),
         ParamFct$new("type.multinomial", levels = c("ungrouped", "grouped"), tags = "train"),
+        ParamUty$new("gamma", tags = "train"),
+        ParamLgl$new("relax", default = FALSE, tags = "train"),
         ParamDbl$new("fdev", default = 1.0e-5, lower = 0, upper = 1, tags = "train"),
         ParamDbl$new("devmax", default = 0.999, lower = 0, upper = 1, tags = "train"),
         ParamDbl$new("eps", default = 1.0e-6, lower = 0, upper = 1, tags = "train"),
@@ -55,6 +57,7 @@ LearnerClassifGlmnet = R6Class("LearnerClassifGlmnet", inherit = LearnerClassif,
         ParamDbl$new("prec", default = 1e-10, tags = "train"),
         ParamInt$new("mxit", default = 100L, lower = 1L, tags = "train")
       ))
+      ps$add_dep("gamma", "relax", CondEqual$new(TRUE))
 
       super$initialize(
         id = "classif.glmnet",

--- a/R/LearnerClassifLDA.R
+++ b/R/LearnerClassifLDA.R
@@ -26,9 +26,13 @@ LearnerClassifLDA = R6Class("LearnerClassifLDA", inherit = LearnerClassif,
   public = list(
     initialize = function() {
       ps = ParamSet$new(list(
+        ParamUty$new("prior", tags = "train"),
+        ParamDbl$new("tol", tags = "train"),
         ParamFct$new("method", default = "moment", levels = c("moment", "mle", "mve", "t"), tags = "train"),
+        ParamInt$new("nu", tags = "train"),
         ParamFct$new("predict.method", default = "plug-in", levels = c("plug-in", "predictive", "debiased"), tags = "predict")
       ))
+      ps$add_dep("nu", "method", CondEqual$new("t"))
 
       super$initialize(
         id = "classif.lda",

--- a/R/LearnerClassifNaiveBayes.R
+++ b/R/LearnerClassifNaiveBayes.R
@@ -23,7 +23,9 @@ LearnerClassifNaiveBayes = R6Class("LearnerClassifNaiveBayes", inherit = Learner
   public = list(
     initialize = function() {
       ps = ParamSet$new(list(
-        ParamDbl$new("laplace", default = 0, lower = 0, tags = "train")
+        ParamDbl$new("laplace", default = 0, lower = 0, tags = "train"),
+        ParamDbl$new("threshold", default = 0.001, tags = "predict"),
+        ParamDbl$new("eps", default = 0, tags = "predict")
       ))
 
       super$initialize(
@@ -44,13 +46,14 @@ LearnerClassifNaiveBayes = R6Class("LearnerClassifNaiveBayes", inherit = Learner
     },
 
     predict_internal = function(task) {
+      pars = self$param_set$get_values(tags = "predict")
       newdata = task$data(cols = task$feature_names)
 
       if (self$predict_type == "response") {
-        response = predict(self$model, newdata = newdata, type = "class")
+        response = invoke(predict, self$model, newdata = newdata, type = "class", .args = pars)
         PredictionClassif$new(task = task, response = response)
       } else {
-        prob = predict(self$model, newdata = newdata, type = "raw")
+        prob = invoke(predict, self$model, newdata = newdata, type = "raw", .args = pars)
         PredictionClassif$new(task = task, prob = prob)
       }
     }

--- a/R/LearnerClassifQDA.R
+++ b/R/LearnerClassifQDA.R
@@ -26,9 +26,12 @@ LearnerClassifQDA = R6Class("LearnerClassifQDA", inherit = LearnerClassif,
   public = list(
     initialize = function() {
       ps = ParamSet$new(list(
+        ParamUty$new("prior", tags = "train"),
         ParamFct$new("method", default = "moment", levels = c("moment", "mle", "mve", "t"), tags = "train"),
+        ParamInt$new("nu", tags = "train"),
         ParamFct$new("predict.method", default = "plug-in", levels = c("plug-in", "predictive", "debiased", "looCV"), tags = "predict")
       ))
+      ps$add_dep("nu", "method", CondEqual$new("t"))
 
       super$initialize(
         id = "classif.qda",

--- a/R/LearnerClassifRanger.R
+++ b/R/LearnerClassifRanger.R
@@ -35,7 +35,7 @@ LearnerClassifRanger = R6Class("LearnerClassifRanger", inherit = LearnerClassif,
         ParamInt$new("min.node.size", default = 1L, lower = 1L, tags = "train"), # for probability == TRUE, def = 10
         ParamLgl$new("replace", default = TRUE, tags = "train"),
         ParamDbl$new("sample.fraction", lower = 0L, upper = 1L, tags = "train"), # for replace == FALSE, def = 0.632
-        # ParamDbl$new("class.weights", defaul = NULL, tags = "train"), #
+        ParamDbl$new("class.weights", defaul = NULL, tags = "train"),
         ParamFct$new("splitrule", levels = c("gini", "extratrees"), default = "gini", tags = "train"),
         ParamInt$new("num.random.splits", lower = 1L, default = 1L, tags = "train"), # requires = quote(splitrule == "extratrees")
         ParamDbl$new("split.select.weights", lower = 0, upper = 1, tags = "train"),
@@ -49,6 +49,8 @@ LearnerClassifRanger = R6Class("LearnerClassifRanger", inherit = LearnerClassif,
         ParamLgl$new("verbose", default = TRUE, tags = c("train", "predict")),
         ParamLgl$new("oob.error", default = TRUE, tags = "train")
       ))
+      ps$add_dep("num.random.splits", "splitrule", CondEqual$new("extratrees"))
+      ps$add_dep("scale.permutation.importance", "importance", CondEqual$new("permutation"))
 
       super$initialize(
         id = "classif.ranger",

--- a/R/LearnerClassifRanger.R
+++ b/R/LearnerClassifRanger.R
@@ -35,7 +35,7 @@ LearnerClassifRanger = R6Class("LearnerClassifRanger", inherit = LearnerClassif,
         ParamInt$new("min.node.size", default = 1L, lower = 1L, tags = "train"), # for probability == TRUE, def = 10
         ParamLgl$new("replace", default = TRUE, tags = "train"),
         ParamDbl$new("sample.fraction", lower = 0L, upper = 1L, tags = "train"), # for replace == FALSE, def = 0.632
-        ParamDbl$new("class.weights", defaul = NULL, tags = "train"),
+        ParamDbl$new("class.weights", defaul = NULL, special_vals = list(NULL), tags = "train"),
         ParamFct$new("splitrule", levels = c("gini", "extratrees"), default = "gini", tags = "train"),
         ParamInt$new("num.random.splits", lower = 1L, default = 1L, tags = "train"), # requires = quote(splitrule == "extratrees")
         ParamDbl$new("split.select.weights", lower = 0, upper = 1, tags = "train"),

--- a/R/LearnerClassifSVM.R
+++ b/R/LearnerClassifSVM.R
@@ -26,12 +26,12 @@ LearnerClassifSVM = R6Class("LearnerClassifSVM", inherit = LearnerClassif,
     initialize = function() {
       ps = ParamSet$new(list(
         ParamFct$new("type", default = "C-classification", levels = c("C-classification", "nu-classification"), tags = "train"),
-        ParamDbl$new("cost", default = 1, lower = 0, tags = "train"), # requires = quote(type == "C-classification")),
-        ParamDbl$new("nu", default = 0.5, tags = "train"), # requires = quote(type == "nu-classification")),
+        ParamDbl$new("cost", default = 1, lower = 0, tags = "train"),
+        ParamDbl$new("nu", default = 0.5, tags = "train"),
         ParamFct$new("kernel", default = "radial", levels = c("linear", "polynomial", "radial", "sigmoid"), tags = "train"),
-        ParamInt$new("degree", default = 3L, lower = 1L, tags = "train"), # requires = quote(kernel == "polynomial")),
-        ParamDbl$new("coef0", default = 0, tags = "train"), # requires = quote(kernel == "polynomial" || kernel == "sigmoid")),
-        ParamDbl$new("gamma", lower = 0, tags = "train"), # requires = quote(kernel != "linear")),
+        ParamInt$new("degree", default = 3L, lower = 1L, tags = "train"),
+        ParamDbl$new("coef0", default = 0, tags = "train"),
+        ParamDbl$new("gamma", lower = 0, tags = "train"),
         ParamDbl$new("cachesize", default = 40L, tags = "train"),
         ParamDbl$new("tolerance", default = 0.001, lower = 0, tags = "train"),
         ParamLgl$new("shrinking", default = TRUE, tags = "train"),
@@ -39,6 +39,11 @@ LearnerClassifSVM = R6Class("LearnerClassifSVM", inherit = LearnerClassif,
         ParamLgl$new("fitted", default = TRUE, tags = "train"), # tunable = FALSE),
         ParamUty$new("scale", default = TRUE, tags = "train") # , tunable = TRUE)
       ))
+      ps$add_dep("cost", "type", CondEqual$new("C-classification"))
+      ps$add_dep("nu", "type", CondEqual$new("nu-classification"))
+      ps$add_dep("degree", "kernel", CondEqual$new("polynomial"))
+      ps$add_dep("coef0", "kernel", CondAnyOf$new(c("polynomial", "sigmoid")))
+      ps$add_dep("gamma", "kernel", CondAnyOf$new(c("polynomial", "radial", "sigmoid")))
 
       super$initialize(
         id = "classif.svm",

--- a/R/LearnerClassifSVM.R
+++ b/R/LearnerClassifSVM.R
@@ -37,7 +37,8 @@ LearnerClassifSVM = R6Class("LearnerClassifSVM", inherit = LearnerClassif,
         ParamLgl$new("shrinking", default = TRUE, tags = "train"),
         ParamInt$new("cross", default = 0L, lower = 0L, tags = "train"), # tunable = FALSE),
         ParamLgl$new("fitted", default = TRUE, tags = "train"), # tunable = FALSE),
-        ParamUty$new("scale", default = TRUE, tags = "train") # , tunable = TRUE)
+        ParamUty$new("scale", default = TRUE, tags = "train"), # , tunable = TRUE)
+        ParamUty$new("class.weights", default = NULL, tags = "train")
       ))
       ps$add_dep("cost", "type", CondEqual$new("C-classification"))
       ps$add_dep("nu", "type", CondEqual$new("nu-classification"))

--- a/R/LearnerClassifXgboost.R
+++ b/R/LearnerClassifXgboost.R
@@ -79,6 +79,7 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost", inherit = LearnerClassi
     },
 
     train_internal = function(task) {
+
       pars = self$param_set$get_values(tags = "train")
 
       lvls = task$class_names
@@ -115,6 +116,7 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost", inherit = LearnerClassi
     },
 
     predict_internal = function(task) {
+
       pars = self$param_set$get_values(tags = "predict")
       model = self$model
       response = prob = NULL

--- a/R/LearnerRegrGlmnet.R
+++ b/R/LearnerRegrGlmnet.R
@@ -28,6 +28,7 @@ LearnerRegrGlmnet = R6Class("LearnerRegrGlmnet", inherit = LearnerRegr,
     initialize = function() {
       ps = ParamSet$new(list(
         ParamFct$new("family", default = "gaussian", levels = c("gaussian", "poisson"), tags = "train"),
+        ParamUty$new("offset", default = NULL, tags = "train"),
         ParamDbl$new("alpha", default = 1, lower = 0, upper = 1, tags = "train"),
         ParamInt$new("nfolds", lower = 3L, default = 10L, tags = "train"),
         ParamFct$new("type.measure", levels = c("deviance", "class", "auc", "mse", "mae"), default = "deviance", tags = "train"),

--- a/R/LearnerRegrGlmnet.R
+++ b/R/LearnerRegrGlmnet.R
@@ -47,6 +47,8 @@ LearnerRegrGlmnet = R6Class("LearnerRegrGlmnet", inherit = LearnerRegr,
         ParamInt$new("maxit", default = 100000L, lower = 1L, tags = "train"),
         ParamFct$new("type.logistic", levels = c("Newton", "modified.Newton"), tags = "train"),
         ParamFct$new("type.multinomial", levels = c("ungrouped", "grouped"), tags = "train"),
+        ParamUty$new("gamma", tags = "train"),
+        ParamLgl$new("relax", default = FALSE, tags = "train"),
         ParamDbl$new("fdev", default = 1.0e-5, lower = 0, upper = 1, tags = "train"),
         ParamDbl$new("devmax", default = 0.999, lower = 0, upper = 1, tags = "train"),
         ParamDbl$new("eps", default = 1.0e-6, lower = 0, upper = 1, tags = "train"),
@@ -57,6 +59,8 @@ LearnerRegrGlmnet = R6Class("LearnerRegrGlmnet", inherit = LearnerRegr,
         ParamDbl$new("prec", default = 1e-10, tags = "train"),
         ParamInt$new("mxit", default = 100L, lower = 1L, tags = "train")
       ))
+      ps$add_dep("gamma", "relax", CondEqual$new(TRUE))
+
       ps$values = list(family = "gaussian")
 
       super$initialize(

--- a/R/LearnerRegrGlmnet.R
+++ b/R/LearnerRegrGlmnet.R
@@ -46,6 +46,7 @@ LearnerRegrGlmnet = R6Class("LearnerRegrGlmnet", inherit = LearnerRegr,
         ParamUty$new("lower.limits", tags = "train"),
         ParamUty$new("upper.limits", tags = "train"),
         ParamInt$new("maxit", default = 100000L, lower = 1L, tags = "train"),
+        ParamFct$new("type.gaussian", levels = c("covariance", "naive"), tags = "train"),
         ParamFct$new("type.logistic", levels = c("Newton", "modified.Newton"), tags = "train"),
         ParamFct$new("type.multinomial", levels = c("ungrouped", "grouped"), tags = "train"),
         ParamUty$new("gamma", tags = "train"),
@@ -61,6 +62,7 @@ LearnerRegrGlmnet = R6Class("LearnerRegrGlmnet", inherit = LearnerRegr,
         ParamInt$new("mxit", default = 100L, lower = 1L, tags = "train")
       ))
       ps$add_dep("gamma", "relax", CondEqual$new(TRUE))
+      ps$add_dep("type.gaussian", "family", CondEqual$new("gaussian"))
 
       ps$values = list(family = "gaussian")
 

--- a/R/LearnerRegrKM.R
+++ b/R/LearnerRegrKM.R
@@ -68,13 +68,14 @@ LearnerRegrKM = R6Class("LearnerRegrKM", inherit = LearnerRegr,
     },
 
     train_internal = function(task) {
+
       pars = self$param_set$get_values(tags = "train")
       data = as.matrix(task$data(cols = task$feature_names))
       truth = task$truth()
 
-      if(!is.null(pars$optim.method)) {
-        if(pars$optim.method == "gen" && !requireNamespace("rgenoud", quietly = TRUE)) {
-          Stop("rgenoud package required for optimization method gen")
+      if (!is.null(pars$optim.method)) {
+        if (pars$optim.method == "gen" && !requireNamespace("rgenoud", quietly = TRUE)) {
+          stop("The 'rgenoud' package is required for optimization method 'gen'.")
         }
       }
 

--- a/R/LearnerRegrKM.R
+++ b/R/LearnerRegrKM.R
@@ -32,12 +32,30 @@ LearnerRegrKM = R6Class("LearnerRegrKM", inherit = LearnerRegr,
     initialize = function() {
       ps = ParamSet$new(list(
         ParamFct$new("covtype", default = "matern5_2", levels = c("gauss", "matern5_2", "matern3_2", "exp", "powexp"), tags = "train"),
+        ParamUty$new("coef.trend", default = NULL, tags = "train"),
+        ParamUty$new("coef.cov", default = NULL, tags = "train"),
+        ParamUty$new("coef.var", default = NULL, tags = "train"),
         ParamDbl$new("nugget", tags = "train"),
         ParamLgl$new("nugget.estim", default = FALSE, tags = "train"),
-        ParamFct$new("type", default = "SK", levels = c("SK", "UK"), tags = "predict"),
         ParamDbl$new("nugget.stability", default = 0, lower = 0, tags = "train"),
+        ParamUty$new("noise.var", default = NULL, tags = "train"),
+        ParamFct$new("estim.method", default = "MLE", levels = c("MLE", "LOO"), tags = "train"),
+        ParamUty$new("penalty", default = NULL, tags = "train"),
+        ParamFct$new("optim.method", default = "BFGS", levels = c("BFGS", "gen"), tags = "train"), # gen requires rgenoud package
+        ParamUty$new("parinit", default = NULL, tags = "train"),
+        ParamInt$new("multistart", default = 1, tags = "train"),
+        ParamUty$new("lower", default = NULL, tags = "train"),
+        ParamUty$new("upper", default = NULL, tags = "train"),
+        ParamLgl$new("gr", default = TRUE, tags = "train"),
+        ParamLgl$new("iso", default = FALSE, tags = "train"),
+        ParamLgl$new("scaling", default = FALSE, tags = "train"),
+        ParamUty$new("knots", default = NULL, tags = "train"),
+        ParamUty$new("kernel", default = NULL, tags = "train"),
+        ParamFct$new("type", default = "SK", levels = c("SK", "UK"), tags = "predict"),
         ParamDbl$new("jitter", default = 0, lower = 0, tags = "predict")
       ))
+      ps$add_dep("multistart", "optim.method", CondEqual$new("BFGS"))
+      ps$add_dep("knots", "scaling", CondEqual$new(TRUE))
 
       super$initialize(
         id = "regr.km",

--- a/R/LearnerRegrKM.R
+++ b/R/LearnerRegrKM.R
@@ -41,7 +41,7 @@ LearnerRegrKM = R6Class("LearnerRegrKM", inherit = LearnerRegr,
         ParamUty$new("noise.var", default = NULL, tags = "train"),
         ParamFct$new("estim.method", default = "MLE", levels = c("MLE", "LOO"), tags = "train"),
         ParamUty$new("penalty", default = NULL, tags = "train"),
-        ParamFct$new("optim.method", default = "BFGS", levels = c("BFGS", "gen"), tags = "train"), # gen requires rgenoud package
+        ParamFct$new("optim.method", default = "BFGS", levels = c("BFGS", "gen"), tags = "train"),
         ParamUty$new("parinit", default = NULL, tags = "train"),
         ParamInt$new("multistart", default = 1, tags = "train"),
         ParamUty$new("lower", default = NULL, tags = "train"),
@@ -71,6 +71,10 @@ LearnerRegrKM = R6Class("LearnerRegrKM", inherit = LearnerRegr,
       pars = self$param_set$get_values(tags = "train")
       data = as.matrix(task$data(cols = task$feature_names))
       truth = task$truth()
+
+      if(pars$optim.method == "gen" && !requireNamespace("rgenoud", quietly = TRUE)) {
+        stop("For optimization method gen, rgenoud package must be installed.")
+      }
 
       ns = pars$nugget.stability
       if (!is.null(ns)) {

--- a/R/LearnerRegrKM.R
+++ b/R/LearnerRegrKM.R
@@ -72,8 +72,8 @@ LearnerRegrKM = R6Class("LearnerRegrKM", inherit = LearnerRegr,
       data = as.matrix(task$data(cols = task$feature_names))
       truth = task$truth()
 
-      if(pars$optim.method == "gen") {
-        if(!requireNamespace("rgenoud", quietly = TRUE)) {
+      if(!is.null(pars$optim.method)) {
+        if(pars$optim.method == "gen" && !requireNamespace("rgenoud", quietly = TRUE)) {
           Stop("rgenoud package required for optimization method gen")
         }
       }

--- a/R/LearnerRegrKM.R
+++ b/R/LearnerRegrKM.R
@@ -72,8 +72,10 @@ LearnerRegrKM = R6Class("LearnerRegrKM", inherit = LearnerRegr,
       data = as.matrix(task$data(cols = task$feature_names))
       truth = task$truth()
 
-      if(pars$optim.method == "gen" && !requireNamespace("rgenoud", quietly = TRUE)) {
-        stop("For optimization method gen, rgenoud package must be installed.")
+      if(pars$optim.method == "gen") {
+        if(!requireNamespace("rgenoud", quietly = TRUE)) {
+          Stop("rgenoud package required for optimization method gen")
+        }
       }
 
       ns = pars$nugget.stability

--- a/R/LearnerRegrRanger.R
+++ b/R/LearnerRegrRanger.R
@@ -35,13 +35,14 @@ LearnerRegrRanger = R6Class("LearnerRegrRanger", inherit = LearnerRegr,
         ParamInt$new("min.node.size", default = 5L, lower = 1L, tags = "train"), # for probability == TRUE, def = 10
         ParamLgl$new("replace", default = TRUE, tags = "train"),
         ParamDbl$new("sample.fraction", lower = 0L, upper = 1L, tags = "train"), # for replace == FALSE, def = 0.632
-        # ParamDbl$new("class.weights", defaul = NULL, tags = "train"), #
         ParamFct$new("splitrule", levels = c("variance", "extratrees", "maxstat"), default = "variance", tags = "train"),
-        ParamInt$new("num.random.splits", lower = 1L, default = 1L, tags = "train"), # requires = quote(splitrule == "extratrees")
+        ParamInt$new("num.random.splits", lower = 1L, default = 1L, tags = "train"),
+        ParamDbl$new("alpha", default = 0.5, tags = "train"),
+        ParamDbl$new("minprop", default = 0.1, tags = "train"),
         ParamDbl$new("split.select.weights", lower = 0, upper = 1, tags = "train"),
         ParamUty$new("always.split.variables", tags = "train"),
         ParamFct$new("respect.unordered.factors", levels = c("ignore", "order", "partition"), default = "ignore", tags = "train"), # for splitrule == "extratrees", def = partition
-        ParamLgl$new("scale.permutation.importance", default = FALSE, tags = "train"), # requires = quote(importance == "permutation")
+        ParamLgl$new("scale.permutation.importance", default = FALSE, tags = "train"),
         ParamLgl$new("keep.inbag", default = FALSE, tags = "train"),
         ParamLgl$new("holdout", default = FALSE, tags = "train"), # FIXME: do we need this?
         ParamInt$new("num.threads", lower = 1L, tags = c("train", "predict")),
@@ -49,6 +50,11 @@ LearnerRegrRanger = R6Class("LearnerRegrRanger", inherit = LearnerRegr,
         ParamLgl$new("verbose", default = TRUE, tags = c("train", "predict")),
         ParamLgl$new("oob.error", default = TRUE, tags = "train")
       ))
+      ps$add_dep("num.random.splits", "splitrule", CondEqual$new("extratrees"))
+      ps$add_dep("alpha", "splitrule", CondEqual$new("maxstat"))
+      ps$add_dep("minprop", "splitrule", CondEqual$new("maxstat"))
+      ps$add_dep("scale.permutation.importance", "importance", CondEqual$new("permutation"))
+
 
       super$initialize(
         id = "regr.ranger",

--- a/R/LearnerRegrSVM.R
+++ b/R/LearnerRegrSVM.R
@@ -27,19 +27,25 @@ LearnerRegrSVM = R6Class("LearnerRegrSVM", inherit = LearnerRegr,
       ps = ParamSet$new(list(
         ParamFct$new("type", default = "eps-regression", levels = c("eps-regression", "nu-regression"), tags = "train"),
         ParamFct$new("kernel", default = "radial", levels = c("linear", "polynomial", "radial", "sigmoid"), tags = "train"),
-        ParamInt$new("degree", default = 3L, lower = 1L, tags = "train"), # requires = quote(kernel == "polynomial")),
-        ParamDbl$new("coef0", default = 0, tags = "train"), # requires = quote(kernel == "polynomial" || kernel == "sigmoid")),
-        ParamDbl$new("cost", default = 1, lower = 0, tags = "train"), # , requires = quote(type == "C-regrication")),
-        ParamDbl$new("nu", default = 0.5, tags = "train"), # , requires = quote(type == "nu-regression")),
-        ParamDbl$new("gamma", lower = 0, tags = "train"), # requires = quote(kernel != "linear")),
+        ParamInt$new("degree", default = 3L, lower = 1L, tags = "train"),
+        ParamDbl$new("coef0", default = 0, tags = "train"),
+        ParamDbl$new("cost", default = 1, lower = 0, tags = "train"),
+        ParamDbl$new("nu", default = 0.5, tags = "train"),
+        ParamDbl$new("gamma", lower = 0, tags = "train"),
         ParamDbl$new("cachesize", default = 40L, tags = "train"),
         ParamDbl$new("tolerance", default = 0.001, lower = 0, tags = "train"),
-        ParamDbl$new("epsilon", lower = 0, tags = "train"), # , requires = quote(type == "eps-regression")),
+        ParamDbl$new("epsilon", lower = 0, tags = "train"),
         ParamLgl$new("shrinking", default = TRUE, tags = "train"),
         ParamInt$new("cross", default = 0L, lower = 0L, tags = "train"), # tunable = FALSE),
         ParamLgl$new("fitted", default = TRUE, tags = "train"), # tunable = FALSE),
         ParamUty$new("scale", default = TRUE, tags = "train") # , tunable = TRUE)
       ))
+      ps$add_dep("cost", "type", CondEqual$new("C-classification"))
+      ps$add_dep("nu", "type", CondEqual$new("nu-classification"))
+      ps$add_dep("degree", "kernel", CondEqual$new("polynomial"))
+      ps$add_dep("coef0", "kernel", CondAnyOf$new(c("polynomial", "sigmoid")))
+      ps$add_dep("gamma", "kernel", CondAnyOf$new(c("polynomial", "radial", "sigmoid")))
+      ps$add_dep("epsilon", "type", CondEqual$new("eps-regression"))
 
       super$initialize(
         id = "regr.svm",


### PR DESCRIPTION
Closes #9 
Closes #27 

- [x] Glmnet
Updated to glmnet 3.0
- [x] KKNN
Not sure if `y-kernel` should be implemented 
- [x] LDA
- [ ]  LogReg
- [x] NaiveBayes
- [x] QDA
- [x] Ranger
- [x] SVM
- [x] Xgboost
Parameters updated in #31
- [x] KM
- [ ] LM

- `CV` parameter for internal cross-validation are not included
- Should we include `na.action` if the options are fail or omit records with missing values? This would add the `missing` property to the learner but only if `na.action` is set to `omit`. Some of the learners  in the list support this.
- We could add parameters like `offset`, `contrast` and `singular.ok` to `LogReg` and `LM`? But they were not included in `mlr`. Do we want this?


