### PR TITLE
Fix Paramtest for glmnet, add predict.gamma and newoffset arg

### DIFF
--- a/R/LearnerClassifGlmnet.R
+++ b/R/LearnerClassifGlmnet.R
@@ -70,7 +70,9 @@ LearnerClassifGlmnet = R6Class("LearnerClassifGlmnet",
         ParamDbl$new("pmin", default = 1.0e-9, lower = 0, upper = 1, tags = "train"),
         ParamDbl$new("exmx", default = 250.0, tags = "train"),
         ParamDbl$new("prec", default = 1e-10, tags = "train"),
-        ParamInt$new("mxit", default = 100L, lower = 1L, tags = "train")
+        ParamInt$new("mxit", default = 100L, lower = 1L, tags = "train"),
+        ParamUty$new("newoffset", tags = "predict"),
+        ParamDbl$new("predict.gamma", default = 1, tags = "predict")
       ))
       ps$add_dep("gamma", "relax", CondEqual$new(TRUE))
 
@@ -87,6 +89,7 @@ LearnerClassifGlmnet = R6Class("LearnerClassifGlmnet",
   ),
 
   private = list(
+
     .train = function(task) {
 
       pars = self$param_set$get_values(tags = "train")
@@ -113,6 +116,11 @@ LearnerClassifGlmnet = R6Class("LearnerClassifGlmnet",
     .predict = function(task) {
       pars = self$param_set$get_values(tags = "predict")
       newdata = as.matrix(task$data(cols = task$feature_names))
+
+      if (!is.null(pars$predict.gamma)) {
+        pars$gamma = pars$predict.gamma
+        pars$predict.gamma = NULL
+      }
 
       if (self$predict_type == "response") {
         response = mlr3misc::invoke(predict, self$model,

--- a/R/LearnerRegrGlmnet.R
+++ b/R/LearnerRegrGlmnet.R
@@ -72,7 +72,9 @@ LearnerRegrGlmnet = R6Class("LearnerRegrGlmnet",
         ParamDbl$new("pmin", default = 1.0e-9, lower = 0, upper = 1, tags = "train"),
         ParamDbl$new("exmx", default = 250.0, tags = "train"),
         ParamDbl$new("prec", default = 1e-10, tags = "train"),
-        ParamInt$new("mxit", default = 100L, lower = 1L, tags = "train")
+        ParamInt$new("mxit", default = 100L, lower = 1L, tags = "train"),
+        ParamUty$new("newoffset", tags = "predict"),
+        ParamDbl$new("predict.gamma", default = 1, tags = "predict")
       ))
       ps$add_dep("gamma", "relax", CondEqual$new(TRUE))
       ps$add_dep("type.gaussian", "family", CondEqual$new("gaussian"))
@@ -91,6 +93,7 @@ LearnerRegrGlmnet = R6Class("LearnerRegrGlmnet",
   ),
 
   private = list(
+
     .train = function(task) {
 
       pars = self$param_set$get_values(tags = "train")
@@ -116,6 +119,11 @@ LearnerRegrGlmnet = R6Class("LearnerRegrGlmnet",
     .predict = function(task) {
       pars = self$param_set$get_values(tags = "predict")
       newdata = as.matrix(task$data(cols = task$feature_names))
+
+      if (!is.null(pars$predict.gamma)) {
+        pars$gamma = pars$predict.gamma
+        pars$predict.gamma = NULL
+      }
 
       response = invoke(predict, self$model, newx = newdata, type = "response", .args = pars)
       PredictionRegr$new(task = task, response = drop(response))

--- a/inst/paramtest/test_paramtest_classif.glmnet.R
+++ b/inst/paramtest/test_paramtest_classif.glmnet.R
@@ -30,13 +30,15 @@ test_that("classif.glmnet", {
     paste0("- '", ParamTest$missing, "'", collapse = "‚")))
 })
 
-test_that("predict classif.glmnet", {
-  learner = lrn("classif.glmnet")
-  fun = glmnet:::predict.cv.glmnet
+test_that("predict regr.glmnet", {
+  learner = lrn("regr.glmnet")
+  fun = glmnet::predict.glmnet
   exclude = c(
     "object", # handled via mlr3
     "newx", # handled via mlr3
-    "s" # automatically set by glmnet via the best value from internal tuning
+    "s", # automatically set by glmnet via the best value from internal tuning
+    "type", # handled via mlr3
+    "exact" # because "s" is not supplied by the user here, "exact" has no influence
   )
 
   ParamTest = run_paramtest(learner, fun, exclude)

--- a/inst/paramtest/test_paramtest_regr.glmnet.R
+++ b/inst/paramtest/test_paramtest_regr.glmnet.R
@@ -32,11 +32,13 @@ test_that("regr.glmnet", {
 
 test_that("predict regr.glmnet", {
   learner = lrn("regr.glmnet")
-  fun = glmnet:::predict.cv.glmnet
+  fun = glmnet::predict.glmnet
   exclude = c(
     "object", # handled via mlr3
     "newx", # handled via mlr3
-    "s" # automatically set by glmnet via the best value from internal tuning
+    "s", # automatically set by glmnet via the best value from internal tuning
+    "type", # handled via mlr3
+    "exact" # because "s" is not supplied by the user here, "exact" has no influence
   )
 
   ParamTest = run_paramtest(learner, fun, exclude)


### PR DESCRIPTION
fixes #93 

New parameters for glmnet:

- predict.gamma (gamma at predict-time)
- newoffset

Paramtest now uses `predict.glmnet()` instead of the non-existent `predict.cv.glmnet()`.