### PR TITLE
GHA: Install bibtex in CI

### DIFF
--- a/tic.R
+++ b/tic.R
@@ -1,5 +1,8 @@
 # R CMD check
 if (!ci_has_env("PARAMTEST")) {
+  get_stage("install") %>%
+    add_step(step_install_cran("bibtex"))
+
   do_package_checks()
 } else {
   # PARAMTEST


### PR DESCRIPTION
To avoid the `cannot load citation` annotations in the windows builds