### PR TITLE
Remove predict.all from ranger

### DIFF
--- a/R/LearnerClassifRanger.R
+++ b/R/LearnerClassifRanger.R
@@ -57,7 +57,6 @@ LearnerClassifRanger = R6Class("LearnerClassifRanger",
         ParamLgl$new("regularization.usedepth", default = FALSE, tags = "train"),
         ParamInt$new("seed", default = NULL, special_vals = list(NULL), tags = "train"),
         ParamDbl$new("minprop", default = 0.1, tags = "train"),
-        ParamLgl$new("predict.all", default = FALSE, tags = "predict"),
         # FIXME: only works if predict_type == "se". How to set dependency?
         ParamFct$new("se.method",
           default = "infjack", levels = c("jack", "infjack"),

--- a/R/LearnerRegrRanger.R
+++ b/R/LearnerRegrRanger.R
@@ -62,7 +62,6 @@ LearnerRegrRanger = R6Class("LearnerRegrRanger",
           default = NULL, special_vals = list(NULL),
           tags = c("train", "predict")),
         ParamLgl$new("quantreg", default = FALSE, tags = "train"),
-        ParamLgl$new("predict.all", default = FALSE, tags = "predict"),
         # FIXME: only works if predict_type == "se". How to set dependency?
         ParamFct$new("se.method",
           default = "infjack", levels = c("jack", "infjack"),

--- a/inst/paramtest/test_paramtest_classif.ranger.R
+++ b/inst/paramtest/test_paramtest_classif.ranger.R
@@ -31,6 +31,7 @@ test_that("predict classif.ranger", {
   exclude = c(
     "quantiles", # required type not supported in mlr3
     "what", # required type (quantiles) not supported in mlr3
+    "predict.all", # not supported in mlr3
     "formula", # handled via mlr3
     "object", # handled via mlr3
     "data", # handled via mlr3

--- a/inst/paramtest/test_paramtest_regr.ranger.R
+++ b/inst/paramtest/test_paramtest_regr.ranger.R
@@ -30,6 +30,7 @@ test_that("predict regr.ranger", {
   exclude = c(
     "quantiles", # required type not supported in mlr3
     "what", # required type (quantiles) not supported in mlr3
+    "predict.all", # not supported in mlr3
     "formula", # handled via mlr3
     "object", # handled via mlr3
     "data", # handled via mlr3


### PR DESCRIPTION
The `predict.all` hyper-parameter in `predict.ranger` cannot currently be handled in mlr3 as we only allow aggregated predictions in forests. Therefore I've removed this hyper-parameter.

See: https://stackoverflow.com/questions/65972567/how-can-i-save-all-prediction-from-ranger-learner-with-predit-all-true-into-a