### PR TITLE
fix Xgboost's monotone_constraints parameter

### DIFF
--- a/R/LearnerClassifXgboost.R
+++ b/R/LearnerClassifXgboost.R
@@ -66,7 +66,9 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost",
         maximize                = p_lgl(default = NULL, special_vals = list(NULL), tags = "train"),
         min_child_weight        = p_dbl(0, default = 1, tags = c("train", "control")),
         missing                 = p_dbl(default = NA, tags = c("train", "predict"), special_vals = list(NA, NA_real_, NULL)),
-        monotone_constraints    = p_int(-1L, 1L, default = 0L, tags = c("train", "control")),
+        monotone_constraints    = p_uty(default = 0, tags = c("train", "control"), custom_check = function(x) {
+                                    check_integerish(x, lower = -1, upper = 1, any.missing = FALSE, null.ok = TRUE)
+                                  }),
         normalize_type          = p_fct(c("tree", "forest"), default = "tree", tags = "train"),
         nrounds                 = p_int(1L, default = 1, tags = c("train")),
         nthread                 = p_int(1L, default = 1L, tags = c("train", "control", "threads")),

--- a/R/LearnerClassifXgboost.R
+++ b/R/LearnerClassifXgboost.R
@@ -67,7 +67,7 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost",
         min_child_weight        = p_dbl(0, default = 1, tags = c("train", "control")),
         missing                 = p_dbl(default = NA, tags = c("train", "predict"), special_vals = list(NA, NA_real_, NULL)),
         monotone_constraints    = p_uty(default = 0, tags = c("train", "control"), custom_check = function(x) {
-                                    check_integerish(x, lower = -1, upper = 1, any.missing = FALSE, null.ok = TRUE)
+                                    checkmate::check_integerish(x, lower = -1, upper = 1, any.missing = FALSE)
                                   }),
         normalize_type          = p_fct(c("tree", "forest"), default = "tree", tags = "train"),
         nrounds                 = p_int(1L, default = 1, tags = c("train")),

--- a/R/LearnerRegrXgboost.R
+++ b/R/LearnerRegrXgboost.R
@@ -51,7 +51,9 @@ LearnerRegrXgboost = R6Class("LearnerRegrXgboost",
         maximize                = p_lgl(default = NULL, special_vals = list(NULL), tags = "train"),
         min_child_weight        = p_dbl(0, default = 1, tags = "train"),
         missing                 = p_dbl(default = NA, tags = c("train", "predict"), special_vals = list(NA, NA_real_, NULL)),
-        monotone_constraints    = p_int(-1L, 1L, default = 0L, tags = "train"),
+        monotone_constraints    = p_uty(default = 0, tags = c("train", "control"), custom_check = function(x) {
+                                    check_integerish(x, lower = -1, upper = 1, any.missing = FALSE, null.ok = TRUE)
+                                  }),
         normalize_type          = p_fct(c("tree", "forest"), default = "tree", tags = "train"),
         nrounds                 = p_int(1L, tags = "train"),
         nthread                 = p_int(1L, default = 1L, tags = c("train", "threads")),

--- a/R/LearnerRegrXgboost.R
+++ b/R/LearnerRegrXgboost.R
@@ -52,7 +52,7 @@ LearnerRegrXgboost = R6Class("LearnerRegrXgboost",
         min_child_weight        = p_dbl(0, default = 1, tags = "train"),
         missing                 = p_dbl(default = NA, tags = c("train", "predict"), special_vals = list(NA, NA_real_, NULL)),
         monotone_constraints    = p_uty(default = 0, tags = c("train", "control"), custom_check = function(x) {
-                                    check_integerish(x, lower = -1, upper = 1, any.missing = FALSE, null.ok = TRUE)
+                                    checkmate::check_integerish(x, lower = -1, upper = 1, any.missing = FALSE)
                                   }),
         normalize_type          = p_fct(c("tree", "forest"), default = "tree", tags = "train"),
         nrounds                 = p_int(1L, tags = "train"),


### PR DESCRIPTION
`monotone_constraints` can also be a vector of integers of length of the number features(-1, 0, 1, allowed), see e.g., 
https://xgboost.readthedocs.io/en/latest/tutorials/monotonic.html