### PR TITLE
ranger: `split.select.weights` should be `p_uty`

### DIFF
--- a/R/LearnerClassifRanger.R
+++ b/R/LearnerClassifRanger.R
@@ -61,7 +61,7 @@ LearnerClassifRanger = R6Class("LearnerClassifRanger",
         scale.permutation.importance = p_lgl(default = FALSE, tags = "train"),
         se.method                    = p_fct(c("jack", "infjack"), default = "infjack", tags = "predict"),
         seed                         = p_int(default = NULL, special_vals = list(NULL), tags = "train"),
-        split.select.weights         = p_dbl(0, 1, tags = "train"),
+        split.select.weights         = p_uty(default = NULL, tags = "train"),
         splitrule                    = p_fct(c("gini", "extratrees"), default = "gini", tags = "train"),
         verbose                      = p_lgl(default = TRUE, tags = c("train", "predict")),
         write.forest                 = p_lgl(default = TRUE, tags = "train")

--- a/R/LearnerRegrRanger.R
+++ b/R/LearnerRegrRanger.R
@@ -52,7 +52,7 @@ LearnerRegrRanger = R6Class("LearnerRegrRanger",
         scale.permutation.importance = p_lgl(default = FALSE, tags = "train"),
         se.method                    = p_fct(c("jack", "infjack"), default = "infjack", tags = "predict"), # FIXME: only works if predict_type == "se". How to set dependency?
         seed                         = p_int(default = NULL, special_vals = list(NULL), tags = c("train", "predict")),
-        split.select.weights         = p_dbl(0, 1, tags = "train"),
+        split.select.weights         = p_uty(default = NULL, tags = "train"),
         splitrule                    = p_fct(c("variance", "extratrees", "maxstat"), default = "variance", tags = "train"),
         verbose                      = p_lgl(default = TRUE, tags = c("train", "predict")),
         write.forest                 = p_lgl(default = TRUE, tags = "train")

--- a/man/mlr_learners_classif.nnet.Rd
+++ b/man/mlr_learners_classif.nnet.Rd
@@ -38,8 +38,6 @@ lrn("classif.nnet")
    censored \tab logical \tab FALSE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    contrasts \tab list \tab NULL \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    decay \tab numeric \tab 0 \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
-   entropy \tab logical \tab FALSE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
-   linout \tab logical \tab FALSE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    mask \tab list \tab - \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    maxit \tab integer \tab 100 \tab  \tab \eqn{[1, \infty)}{[1, Inf)} \cr
    na.action \tab list \tab - \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
@@ -47,7 +45,6 @@ lrn("classif.nnet")
    reltol \tab numeric \tab 1e-08 \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    size \tab integer \tab 3 \tab  \tab \eqn{[0, \infty)}{[0, Inf)} \cr
    skip \tab logical \tab FALSE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
-   softmax \tab logical \tab FALSE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    subset \tab list \tab - \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    trace \tab logical \tab TRUE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
 }

--- a/man/mlr_learners_classif.ranger.Rd
+++ b/man/mlr_learners_classif.ranger.Rd
@@ -71,7 +71,7 @@ lrn("classif.ranger")
    scale.permutation.importance \tab logical \tab FALSE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    se.method \tab character \tab infjack \tab jack, infjack \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    seed \tab integer \tab NULL \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
-   split.select.weights \tab numeric \tab - \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   split.select.weights \tab list \tab NULL \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    splitrule \tab character \tab gini \tab gini, extratrees \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    verbose \tab logical \tab TRUE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    write.forest \tab logical \tab TRUE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr

--- a/man/mlr_learners_regr.ranger.Rd
+++ b/man/mlr_learners_regr.ranger.Rd
@@ -53,7 +53,7 @@ lrn("regr.ranger")
    scale.permutation.importance \tab logical \tab FALSE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    se.method \tab character \tab infjack \tab jack, infjack \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    seed \tab integer \tab NULL \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
-   split.select.weights \tab numeric \tab - \tab  \tab \eqn{[0, 1]}{[0, 1]} \cr
+   split.select.weights \tab list \tab NULL \tab  \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    splitrule \tab character \tab variance \tab variance, extratrees, maxstat \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    verbose \tab logical \tab TRUE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr
    write.forest \tab logical \tab TRUE \tab TRUE, FALSE \tab \eqn{(-\infty, \infty)}{(-Inf, Inf)} \cr


### PR DESCRIPTION
fixes #176 