### PR TITLE
xgb classif and regr early stopping

### DIFF
--- a/R/LearnerClassifXgboost.R
+++ b/R/LearnerClassifXgboost.R
@@ -208,7 +208,8 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost",
       data = xgboost::xgb.DMatrix(data = data.matrix(data), label = label)
 
       if ("weights" %in% task$properties) {
-        xgboost::setinfo(data, "weight", task$weights$weight)
+        xgboost::setinfo(data, "weight",
+                         subset(task$weights, row_id %in% train_ids)$weight)
       }
 
       if (is.null(pv$watchlist) && is.null(pv$early_stopping_rounds)) {
@@ -221,13 +222,16 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost",
         # If watchlist is not provided as list of xgb.DMatrix's and
         # early_stopping_rounds is set, early stopping will use task validation
         # rows to monitor improvements
-        valid_ids = task$row_roles$validation
         label_valid = nlvls -
           as.integer(task$data(rows = valid_ids, cols = task$target_names)[[1]])
         data_valid = xgboost::xgb.DMatrix(
           data = data.matrix(task$data(rows = valid_ids,
                                        cols = task$feature_names)),
           label = label_valid)
+        if ("weights" %in% task$properties) {
+          xgboost::setinfo(data_valid, "weight",
+                           subset(task$weights, row_id %in% valid_ids)$weight)
+        }
         pv$watchlist = list(validation = data_valid)
       }
 

--- a/R/LearnerClassifXgboost.R
+++ b/R/LearnerClassifXgboost.R
@@ -6,6 +6,15 @@
 #' eXtreme Gradient Boosting classification.
 #' Calls [xgboost::xgb.train()] from package \CRANpkg{xgboost}.
 #'
+#' If you want to use native early stopping `xgboost` implementation
+#' inside training pipeline, please provide validation rows in the task,
+#' set `early_stopping_rounds` value and left `watchlist` as `NULL`.
+#' If `xgb.DMatrix`'s in `watchlist` is provided and `early_stopping_rounds`
+#' is set, early stopping will also work, but such validation datasets will not
+#' processed by learner inside training pipeline, so this is a rare choice.
+#' With `watchlist = NULL` and `early_stopping_rounds = NULL` training will stop
+#' after no improvements during 10 rounds on training set.
+#'
 #' If not specified otherwise, the evaluation metric is set to the default `"logloss"`
 #' for binary classification problems and set to `"mlogloss"` for multiclass problems.
 #' This was necessary to silence a deprecation warning.
@@ -191,19 +200,35 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost",
         }
       )
 
-
-      data = task$data(cols = task$feature_names)
+      train_ids = task$row_roles$use
+      data = task$data(rows = train_ids, cols = task$feature_names)
       # recode to 0:1 to that for the binary case the positive class translates to 1 (#32)
       # note that task$truth() is guaranteed to have the factor levels in the right order
-      label = nlvls - as.integer(task$truth())
+      label = nlvls - as.integer(task$truth(rows = train_ids))
       data = xgboost::xgb.DMatrix(data = data.matrix(data), label = label)
 
       if ("weights" %in% task$properties) {
         xgboost::setinfo(data, "weight", task$weights$weight)
       }
 
-      if (is.null(pv$watchlist)) {
+      if (is.null(pv$watchlist) && is.null(pv$early_stopping_rounds)) {
+        # If watchlist & early_stopping_rounds both are not provided by user,
+        # training will stop after reaching maximum quality on train set
+        # (no further improvements during 10 rounds)
+        pv$early_stopping_rounds = 10 # hardcoded arbitrary value
         pv$watchlist = list(train = data)
+      } else if (is.null(pv$watchlist) && !is.null(pv$early_stopping_rounds)) {
+        # If watchlist is not provided as list of xgb.DMatrix's and
+        # early_stopping_rounds is set, early stopping will use task validation
+        # rows to monitor improvements
+        valid_ids = task$row_roles$validation
+        label_valid = nlvls -
+          as.integer(task$data(rows = valid_ids, cols = task$target_names)[[1]])
+        data_valid = xgboost::xgb.DMatrix(
+          data = data.matrix(task$data(rows = valid_ids,
+                                       cols = task$feature_names)),
+          label = label_valid)
+        pv$watchlist = list(validation = data_valid)
       }
 
       invoke(xgboost::xgb.train, data = data, .args = pv)

--- a/R/LearnerRegrXgboost.R
+++ b/R/LearnerRegrXgboost.R
@@ -164,7 +164,8 @@ LearnerRegrXgboost = R6Class("LearnerRegrXgboost",
       data = xgboost::xgb.DMatrix(data = data.matrix(data), label = data.matrix(target))
 
       if ("weights" %in% task$properties) {
-        xgboost::setinfo(data, "weight", task$weights$weight)
+        xgboost::setinfo(data, "weight",
+                         subset(task$weights, row_id %in% train_ids)$weight)
       }
 
       if (is.null(pv$watchlist) && is.null(pv$early_stopping_rounds)) {
@@ -183,6 +184,10 @@ LearnerRegrXgboost = R6Class("LearnerRegrXgboost",
           data = data.matrix(task$data(rows = valid_ids,
                                        cols = task$feature_names)),
           label = target_valid)
+        if ("weights" %in% task$properties) {
+          xgboost::setinfo(data_valid, "weight",
+                           subset(task$weights, row_id %in% valid_ids)$weight)
+        }
         pv$watchlist = list(validation = data_valid)
       }
 


### PR DESCRIPTION
My second attempt to solve mlr-org/mlr3tuning#216 for xgboost inspired by https://github.com/mlr-org/mlr3extralearners/blob/main/R/learner_lightgbm_classif_lightgbm.R
Short test provided in gists: 
https://gist.github.com/statist-bhfz/2151c26107c8922a344b7004fe64f26a
https://gist.github.com/statist-bhfz/bc7661b9bbf5c6f2e9d3fd72f7b17d1a
I faced with very strange behavior if only factor features are provided (illustrated in https://gist.github.com/statist-bhfz/bc7661b9bbf5c6f2e9d3fd72f7b17d1a). It looks like new feature names after encoding and other preprocessing steps doesn't propagate inside `task` object referred in learner, so only features with unchanged names actually take part in learning.