### PR TITLE
XGBoost: remove `sketch_eps` param

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     rgenoud,
     rmarkdown,
     testthat (>= 3.0.0),
-    xgboost
+    xgboost (>= 1.6.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 NeedsCompilation: no

--- a/R/LearnerClassifXgboost.R
+++ b/R/LearnerClassifXgboost.R
@@ -96,7 +96,6 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost",
         save_name                   = p_uty(default = NULL, tags = "train"),
         save_period                 = p_int(0, default = NULL, special_vals = list(NULL), tags = "train"),
         scale_pos_weight            = p_dbl(default = 1, tags = "train"),
-        sketch_eps                  = p_dbl(0, 1, default = 0.03, tags = "train"),
         skip_drop                   = p_dbl(0, 1, default = 0, tags = "train"),
         strict_shape                = p_lgl(default = FALSE, tags = "predict"),
         subsample                   = p_dbl(0, 1, default = 1, tags = c("train", "control")),
@@ -122,7 +121,6 @@ LearnerClassifXgboost = R6Class("LearnerClassifXgboost",
       ps$add_dep("grow_policy", "tree_method", CondEqual$new("hist"))
       ps$add_dep("max_leaves", "grow_policy", CondEqual$new("lossguide"))
       ps$add_dep("max_bin", "tree_method", CondEqual$new("hist"))
-      ps$add_dep("sketch_eps", "tree_method", CondEqual$new("approx"))
       ps$add_dep("feature_selector", "booster", CondEqual$new("gblinear"))
       ps$add_dep("top_k", "booster", CondEqual$new("gblinear"))
       ps$add_dep("top_k", "feature_selector", CondAnyOf$new(c("greedy", "thrifty")))

--- a/R/LearnerRegrXgboost.R
+++ b/R/LearnerRegrXgboost.R
@@ -80,7 +80,6 @@ LearnerRegrXgboost = R6Class("LearnerRegrXgboost",
         save_period                 = p_int(0, default = NULL, special_vals = list(NULL), tags = "train"),
         scale_pos_weight            = p_dbl(default = 1, tags = "train"),
         seed_per_iteration          = p_lgl(default = FALSE, tags = "train"),
-        sketch_eps                  = p_dbl(0, 1, default = 0.03, tags = "train"),
         skip_drop                   = p_dbl(0, 1, default = 0, tags = "train"),
         strict_shape                = p_lgl(default = FALSE, tags = "predict"),
         subsample                   = p_dbl(0, 1, default = 1, tags = "train"),
@@ -106,7 +105,6 @@ LearnerRegrXgboost = R6Class("LearnerRegrXgboost",
       ps$add_dep("grow_policy", "tree_method", CondEqual$new("hist"))
       ps$add_dep("max_leaves", "grow_policy", CondEqual$new("lossguide"))
       ps$add_dep("max_bin", "tree_method", CondEqual$new("hist"))
-      ps$add_dep("sketch_eps", "tree_method", CondEqual$new("approx"))
       ps$add_dep("feature_selector", "booster", CondEqual$new("gblinear"))
       ps$add_dep("top_k", "booster", CondEqual$new("gblinear"))
       ps$add_dep("top_k", "feature_selector", CondAnyOf$new(c("greedy", "thrifty")))


### PR DESCRIPTION
Removed in [XGBoost 1.6.0](https://github.com/dmlc/xgboost/releases).