### PR TITLE
feat: allow formula as argument for nnet learner

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# mlr3learners 0.5.5
+# mlr3learners 0.5.6-9000
+
+* Added formula argument to `nnet` learner
+
+# mlr3learners 0.5.6
 
 - Enable new early stopping mechanism for xgboost.
 - Improved documentation.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mlr3learners 0.5.6-9000
 
-* Added formula argument to `nnet` learner
+* Added formula argument to `nnet` learner and support feature type `"integer"`
 
 # mlr3learners 0.5.6
 

--- a/R/LearnerClassifNnet.R
+++ b/R/LearnerClassifNnet.R
@@ -17,6 +17,9 @@
 #'   - Adjusted default: 3L.
 #'   - Reason for change: no default in `nnet()`.
 #'
+#' @section Custom mlr3 parameters:
+#' - `formula`: if not provided, the formula is set to `task$formula()`.
+#'
 #' @references
 #' `r format_bib("ripley_1996")`
 #'
@@ -46,7 +49,8 @@ LearnerClassifNnet = R6Class("LearnerClassifNnet",
         size      = p_int(0L, default = 3L, tags = "train"),
         skip      = p_lgl(default = FALSE, tags = "train"),
         subset    = p_uty(tags = "train"),
-        trace     = p_lgl(default = TRUE, tags = "train")
+        trace     = p_lgl(default = TRUE, tags = "train"),
+        formula   = p_uty(tags = "train")
       )
       ps$values = list(size = 3L)
 
@@ -68,9 +72,11 @@ LearnerClassifNnet = R6Class("LearnerClassifNnet",
       if ("weights" %in% task$properties) {
         pv = insert_named(pv, list(weights = task$weights$weight))
       }
-      f = task$formula()
+      if (is.null(pv$formula)) {
+        pv$formula = task$formula()
+      }
       data = task$data()
-      invoke(nnet::nnet.formula, formula = f, data = data, .args = pv)
+      invoke(nnet::nnet.formula, data = data, .args = pv)
     },
 
     .predict = function(task) {

--- a/R/LearnerClassifNnet.R
+++ b/R/LearnerClassifNnet.R
@@ -57,7 +57,7 @@ LearnerClassifNnet = R6Class("LearnerClassifNnet",
       super$initialize(
         id = "classif.nnet",
         packages = c("mlr3learners", "nnet"),
-        feature_types = c("numeric", "factor", "ordered"),
+        feature_types = c("numeric", "factor", "ordered", "integer"),
         predict_types = c("prob", "response"),
         param_set = ps,
         properties = c("twoclass", "multiclass", "weights"),

--- a/R/LearnerRegrNnet.R
+++ b/R/LearnerRegrNnet.R
@@ -17,6 +17,9 @@
 #'   - Adjusted default: 3L.
 #'   - Reason for change: no default in `nnet()`.
 #'
+#' @section Custom mlr3 parameters:
+#' - `formula`: if not provided, the formula is set to `task$formula()`.
+#'
 #' @references
 #' `r format_bib("ripley_1996")`
 #'
@@ -46,7 +49,8 @@ LearnerRegrNnet = R6Class("LearnerRegrNnet",
         size      = p_int(0L, default = 3L, tags = "train"),
         skip      = p_lgl(default = FALSE, tags = "train"),
         subset    = p_uty(tags = "train"),
-        trace     = p_lgl(default = TRUE, tags = "train")
+        trace     = p_lgl(default = TRUE, tags = "train"),
+        formula   = p_uty(tags = "train")
       )
       ps$values = list(size = 3L)
 
@@ -68,10 +72,12 @@ LearnerRegrNnet = R6Class("LearnerRegrNnet",
       if ("weights" %in% task$properties) {
         pv = insert_named(pv, list(weights = task$weights$weight))
       }
-      f = task$formula()
+      if (is.null(pv$formula)) {
+        pv$formula = task$formula()
+      }
       data = task$data()
       # force linout = TRUE for regression
-      invoke(nnet::nnet.formula, formula = f, data = data, linout = TRUE, .args = pv)
+      invoke(nnet::nnet.formula, data = data, linout = TRUE, .args = pv)
     },
 
     .predict = function(task) {

--- a/R/LearnerRegrNnet.R
+++ b/R/LearnerRegrNnet.R
@@ -57,7 +57,7 @@ LearnerRegrNnet = R6Class("LearnerRegrNnet",
       super$initialize(
         id = "regr.nnet",
         packages = c("mlr3learners", "nnet"),
-        feature_types = c("numeric", "factor", "ordered"),
+        feature_types = c("numeric", "factor", "ordered", "integer"),
         predict_types = c("response"),
         param_set = ps,
         properties = c("weights"),

--- a/inst/paramtest/test_paramtest_classif.nnet.R
+++ b/inst/paramtest/test_paramtest_classif.nnet.R
@@ -7,7 +7,6 @@ test_that("classif.nnet", {
     "x", # handled via mlr3
     "y", # handled via mlr3
     "weights", # handled via mlr3
-    "formula", # handled via mlr3
     "data", # handled via mlr3
     "entropy", # automatically set to TRUE if two-class task
     "softmax", # automatically set to TRUE if multi-class task

--- a/inst/paramtest/test_paramtest_regr.nnet.R
+++ b/inst/paramtest/test_paramtest_regr.nnet.R
@@ -7,7 +7,6 @@ test_that("regr.nnet", {
     "x", # handled via mlr3
     "y", # handled via mlr3
     "weights", # handled via mlr3
-    "formula", # handled via mlr3
     "data", # handled via mlr3
     "linout", # automatically set to TRUE, since it's the regression learner
     "entropy", # mutually exclusive with linout

--- a/man/mlr_learners_classif.nnet.Rd
+++ b/man/mlr_learners_classif.nnet.Rd
@@ -25,7 +25,7 @@ lrn("classif.nnet")
 \itemize{
 \item Task type: \dQuote{classif}
 \item Predict Types: \dQuote{response}, \dQuote{prob}
-\item Feature Types: \dQuote{numeric}, \dQuote{factor}, \dQuote{ordered}
+\item Feature Types: \dQuote{integer}, \dQuote{numeric}, \dQuote{factor}, \dQuote{ordered}
 \item Required Packages: \CRANpkg{mlr3}, \CRANpkg{mlr3learners}, \CRANpkg{nnet}
 }
 }

--- a/man/mlr_learners_classif.nnet.Rd
+++ b/man/mlr_learners_classif.nnet.Rd
@@ -49,6 +49,7 @@ lrn("classif.nnet")
    skip \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
    subset \tab untyped \tab - \tab  \tab - \cr
    trace \tab logical \tab TRUE \tab TRUE, FALSE \tab - \cr
+   formula \tab untyped \tab - \tab  \tab - \cr
 }
 }
 
@@ -60,6 +61,13 @@ lrn("classif.nnet")
 \item Adjusted default: 3L.
 \item Reason for change: no default in \code{nnet()}.
 }
+}
+}
+
+\section{Custom mlr3 parameters}{
+
+\itemize{
+\item \code{formula}: if not provided, the formula is set to \code{task$formula()}.
 }
 }
 

--- a/man/mlr_learners_regr.nnet.Rd
+++ b/man/mlr_learners_regr.nnet.Rd
@@ -49,6 +49,7 @@ lrn("regr.nnet")
    skip \tab logical \tab FALSE \tab TRUE, FALSE \tab - \cr
    subset \tab untyped \tab - \tab  \tab - \cr
    trace \tab logical \tab TRUE \tab TRUE, FALSE \tab - \cr
+   formula \tab untyped \tab - \tab  \tab - \cr
 }
 }
 
@@ -60,6 +61,13 @@ lrn("regr.nnet")
 \item Adjusted default: 3L.
 \item Reason for change: no default in \code{nnet()}.
 }
+}
+}
+
+\section{Custom mlr3 parameters}{
+
+\itemize{
+\item \code{formula}: if not provided, the formula is set to \code{task$formula()}.
 }
 }
 

--- a/man/mlr_learners_regr.nnet.Rd
+++ b/man/mlr_learners_regr.nnet.Rd
@@ -25,7 +25,7 @@ lrn("regr.nnet")
 \itemize{
 \item Task type: \dQuote{regr}
 \item Predict Types: \dQuote{response}
-\item Feature Types: \dQuote{numeric}, \dQuote{factor}, \dQuote{ordered}
+\item Feature Types: \dQuote{integer}, \dQuote{numeric}, \dQuote{factor}, \dQuote{ordered}
 \item Required Packages: \CRANpkg{mlr3}, \CRANpkg{mlr3learners}, \CRANpkg{nnet}
 }
 }


### PR DESCRIPTION
Otherwise, interaction effects can e.g. not be specified. See the SO question below

https://stackoverflow.com/questions/75642879/multiple-runs-and-interaction-terms-in-mlr3-regr-nnet-task