### PR TITLE
select features functionality

### DIFF
--- a/R/LearnerClassifRanger.R
+++ b/R/LearnerClassifRanger.R
@@ -83,7 +83,7 @@ LearnerClassifRanger = R6Class("LearnerClassifRanger",
         param_set = ps,
         predict_types = c("response", "prob"),
         feature_types = c("logical", "integer", "numeric", "character", "factor", "ordered"),
-        properties = c("weights", "twoclass", "multiclass", "importance", "oob_error", "hotstart_backward", "missings"),
+        properties = c("weights", "twoclass", "multiclass", "importance", "oob_error", "hotstart_backward", "missings", "selected_features"),
         packages = c("mlr3learners", "ranger"),
         label = "Random Forest",
         man = "mlr3learners::mlr_learners_classif.ranger"
@@ -116,6 +116,14 @@ LearnerClassifRanger = R6Class("LearnerClassifRanger",
         stopf("No model stored")
       }
       self$model$prediction.error
+    }
+
+    #' @description
+    #' The set of features used for node splitting in the forest.
+    #'
+    #' @return `character()`.
+    selected_features = function() {
+      ranger_selected_features(self)
     }
   ),
 

--- a/R/LearnerRegrRanger.R
+++ b/R/LearnerRegrRanger.R
@@ -65,7 +65,7 @@ LearnerRegrRanger = R6Class("LearnerRegrRanger",
         param_set = ps,
         predict_types = c("response", "se", "quantiles"),
         feature_types = c("logical", "integer", "numeric", "character", "factor", "ordered"),
-        properties = c("weights", "importance", "oob_error", "hotstart_backward", "missings"),
+        properties = c("weights", "importance", "oob_error", "hotstart_backward", "missings", "selected_features"),
         packages = c("mlr3learners", "ranger"),
         label = "Random Forest",
         man = "mlr3learners::mlr_learners_regr.ranger"
@@ -98,6 +98,14 @@ LearnerRegrRanger = R6Class("LearnerRegrRanger",
         stopf("No model stored")
       }
       self$model$prediction.error
+    }
+
+    #' @description
+    #' The set of features used for node splitting in the forest.
+    #'
+    #' @return `character()`.
+    selected_features = function() {
+      ranger_selected_features(self)
     }
   ),
 

--- a/R/helpers_ranger.R
+++ b/R/helpers_ranger.R
@@ -34,3 +34,26 @@ convert_ratio = function(pv, target, ratio, n) {
     stopf("Hyperparameters '%s' and '%s' are mutually exclusive", target, ratio)
   )
 }
+
+
+
+
+ranger_selected_features = function(self) {
+  if (is.null(self$model)) {
+    stopf("No model stored")
+  }
+
+  splitvars = ranger::treeInfo(object = self$model, tree = 1)$splitvarName
+  i = 2
+  while (i <= self$model$num.trees &&
+      !all(self$state$feature_names %in% splitvars)) {
+    sv = ranger::treeInfo(object = self$model, tree = i)$splitvarName
+    splitvars = union(splitvars, sv)
+    i = i + 1
+  }
+
+  # order the names of the selected features in the same order as in the task
+  self$state$feature_names[self$state$feature_names %in% splitvars]
+}
+
+

--- a/tests/testthat/test_classif_ranger.R
+++ b/tests/testthat/test_classif_ranger.R
@@ -88,3 +88,12 @@ test_that("default_values", {
   values = default_values(learner, search_space, task)
   expect_names(names(values), permutation.of =  c("replace", "sample.fraction", "num.trees", "mtry.ratio"))
 })
+
+test_that("selected_features", {
+  learner = lrn("classif.ranger")
+  expect_error(learner$selected_features())
+
+  task = tsk("iris")
+  learner$train(task)
+  expect_set_equal(learner$selected_features(), c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"))
+})

--- a/tests/testthat/test_regr_ranger.R
+++ b/tests/testthat/test_regr_ranger.R
@@ -86,3 +86,12 @@ test_that("quantile prediction", {
   expect_names(names(tab), identical.to = c("row_ids", "truth", "q0.1", "q0.5", "q0.9", "response"))
   expect_equal(tab$response, tab$q0.5)
 })
+
+test_that("selected_features", {
+  learner = lrn("regr.ranger")
+  expect_error(learner$selected_features())
+
+  task$select(c("am", "cyl", "wt"))
+  learner$train(task)
+  expect_set_equal(learner$selected_features(), c("am", "cyl", "wt"))
+})


### PR DESCRIPTION
@mllg 

The code adds functionality to extract the selected features from a random forest model (i.e. the features used for node splitting).

My function returns the features in the same order as in the data set. Is this desired?

As I am not an expert on mlr3: Is it possible that self$model is not NULL but there are no features is self$state$feature_names? In this case I should include suitable checks for this.