### PR TITLE
fix: compatibility with glmnet 5.0 in selected_features

### DIFF
--- a/R/helpers_glmnet.R
+++ b/R/helpers_glmnet.R
@@ -43,11 +43,10 @@ glmnet_selected_features = function(self, lambda = NULL) {
   assert_number(lambda, null.ok = TRUE, lower = 0)
   lambda = lambda %??% glmnet_get_lambda(self)
   nonzero = predict(self$model, type = "nonzero", s = lambda)
-  if (is.data.frame(nonzero)) {
-    nonzero = nonzero[[1L]]
+  nonzero = if (is.data.frame(nonzero)) {
+    nonzero[[1L]]
   } else {
-    nonzero = unlist(map(nonzero, 1L), use.names = FALSE)
-    nonzero = if (length(nonzero)) sort(unique(nonzero)) else integer()
+    sort(unique(unlist(nonzero, use.names = FALSE)))
   }
 
   glmnet_feature_names(self$model)[nonzero]


### PR DESCRIPTION
## Summary

- `predict(<glmnet>, type = "nonzero")` in glmnet 5.0 consistently returns a list of integer vectors instead of a data.frame for single-response models. The `else` branch in `glmnet_selected_features()` used `map(nonzero, 1L)` which extracted only position 1 from each vector, collapsing the full index to a single entry.
- Replace with `sort(unique(unlist(nonzero, use.names = FALSE)))` to preserve all nonzero indices. Backward-compatible with glmnet 4.x.

## Test plan

- [x] All 118 glmnet tests pass (`devtools::test(filter = 'glmnet')`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)