### PR TITLE
docs: redocument with roxygen2 8.0.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,4 +88,4 @@ Collate:
     'helpers_ranger.R'
     'helpers_xgboost.R'
     'zzz.R'
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.0.0.9000

--- a/man/mlr3learners-package.Rd
+++ b/man/mlr3learners-package.Rd
@@ -36,6 +36,7 @@ Authors:
 Other contributors:
 \itemize{
   \item Alexander Winterstetter \email{alexanderwinterstetter@gmail.com} [contributor]
+  \item Toby Hocking \email{toby.hocking@r-project.org} (\href{https://orcid.org/0000-0002-3146-0865}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
Regenerate man pages and NAMESPACE with `devtools::document()` using roxygen2 8.0.0.9000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)